### PR TITLE
Fill in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # Governance and Guidance
+
+## Sustainability
+
+One of the main goals of the organizational structure of Tauri is to guarantee the sustainability of Tauri and the health and well-being of its contributors. The world of Open Source is fraught with peril and discord, and we have taken measures to ensure the longevity of Tauri. This repo explains how we go about doing so.
+
+## Organizational Structure
+
+Tauri apps is governed by the community and work is done in the context of public working groups. Each working group has a dedicated channel on the Discord server as well as a Team on GitHub. Other than that, each WG is free to use whatever type of organizational model it chooses.
+
+The current working groups are:
+
+- WG Governance & Guidance
+- WG Tech
+- WG Education
+- WG Media
+- WG Security
+- WG Devops
+
+With the exception of the security working group, which is by invite only and convenes privately, all other working groups are public and open to any and all participants.
+
+## Code of Conduct
+
+Everyone participating in the Tauri community is expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Social Contract
+
+We have a [Social Contract](./SOCIAL_CONTRACT.md) that informs our decision making and organization.
+
+## Licensing
+
+We, the contributors to Tauri Apps, use the MIT and Apache licenses for all code content. Images and bodies of text, unless otherwise noted are CC-BY-ND-NC.
+
+## Trademark
+
+It is a permissible use of the name "Tauri App" or the Tauri logo to show that a project uses Tauri. "Tauri Studio" is reserved for use by the organization.
+
+Any language that gives the impression that the Tauri organization approves, authorizes or otherwise supports a project, person or company is not permissible without written authorization from the Guidance and Governance Working Group.


### PR DESCRIPTION
This populates the readme page of this repo with the information from the tauri-docs repo's governance page. Note that some of this may be out of date (such as WG info) but this PR primarily serves to start shifting this information to a centralised place. 