### PR TITLE
Tauri Board Election 2025 documentation skeleton

### DIFF
--- a/board-election-2025/Candidates.md
+++ b/board-election-2025/Candidates.md
@@ -1,0 +1,13 @@
+# Candidate introductions
+
+Candidates for the [2025 Tauri Board elections](README.md).
+
+## Jacob Bolda
+
+I am Jacob Bolda, [@jbolda][github-jbolda]. Over the years, I led or was involved with many prototypes and first implementations of work we rely on today, such as `create-tauri-app`, the CI/CD and our documentation website. The "type" of time that I have been able to give has evolved with the project over the years, and in recent years, I have found my time best offered and valued in advising, managing, and also speaking about the project on my YouTube channel. Bringing folks in and keeping the project approachable will always be a requirement for the continued success of Tauri.
+
+I assisted Robin in organizing and establishing the Tauri Programme about 4.5 years and joined as a Board Director. My efforts in organizing and advocating for improving management efforts began the year prior to that. I intend to continue these efforts to organize and establish the Tauri community in the most inclusive way I am able. A "theme" that we have been striving for is improving transparency of the organization and the onboarding into roles to further push the project forward.
+
+Frontside Software is the consultancy to which I am employed. I work with as a software engineering consulting for large enterprise. My roles find great overlap in the work and needs of Tauri including engineering architecture, planning, and managing and executing large migrations. As a Director of the Board, I will continue to serve the Tauri community with these skills. We will hone our processes and workflows on the foundations we have established to help our domains achieve the best they are able.
+
+[github-jbolda]: https://github.com/jbolda "Jacob Bolda - GitHub"

--- a/board-election-2025/README.md
+++ b/board-election-2025/README.md
@@ -1,0 +1,75 @@
+# Tauri Board Election 2025
+
+<!-- Summary -->
+
+The Tauri Board is the central decision making body for the Tauri Programme and is responsible for the overall health and stability of the Tauri Programme. It consists of up to 7 elected Board Directors.
+We are **inviting Working Group members** to cast their vote on which candidates they prefer. This document provides more information to help you orient.
+
+**Places you can reach out: [`#general-wg`][discord-general-wg]**
+
+## Election Result
+
+**Pending**
+
+| Name        |   Elected   | Positive votes | Threshold |
+| ----------- | :---------: | -------------: | --------: |
+| Jacob Bolda | **Pending** |              - |         - |
+
+- _Raw votes: [`votes.ndjson`](./votes.ndjson)_
+- _Review: https://github.com/tauri-apps/governance-and-guidance/pull/57_
+
+Taking as reference, currently X people have the Discord `working-group` role.
+A X turnout for the vote based on that number.
+
+The official end of term for the current Directors is _on July 16th_. Both candidates are uncumbants who have already signed [the Pledge][tcc-plege].
+
+[tcc-plege]: https://dracc.commonsconservancy.org/0016/
+
+## Dates
+
+Candidate applications: until July 7nd, 2025<br>
+Voting dates: July 7th through July 14th, 2025<br>
+Results: on or before July 16, 2025
+
+## Candidates
+
+- [Jacob Bolda][jacob-bolda] - _Candidate for a third term._
+
+[jacob-bolda]: Candidates.md#jacob-bolda "Candidates.md - Jacob Bolda"
+
+## More information
+
+_We're hoping to provide clear and complete information. If you have any questions after reading this section, don't hesitate to ask!_
+
+### Available positions
+
+Currently all 7 Director positions are filled. For 5 Directors their term ends this July.
+This election determines who is appointed those 5 seats for the next 2 years (a full term).
+
+### Will all seats be filled?
+
+The minimum is 3 Directors total. So not all seats have to be filled. Only when _at least half_ of the voters indicate they're _for_ appointing a candidate, would a seat be filled.
+
+In other words candidates will not be appointed "by default" to fill as many seats as possible. Only when they have the confidence of voters.
+
+### How does voting work?
+
+In this election we have 5 seats available and X candidates. For each candidate voters indicate whether they're for or against that candidate becoming a Board Director. Each candidate needs to meet a "confidence threshold", meaning at least (`>=`) 50% of voters have voted _"Yes"_ for that candidate.
+
+You can use the voting tool that lets you drag and drop candidates to create your vote.
+To submit your vote, it generates an email for you to send with a human and machine readable format. When the voting period ends, those votes are counted and compiled into a result.
+
+### Can someone run for multiple terms?
+
+As per [Tauri's statutes][statutes-governance]:
+
+> Directors are permitted to seek office for multiple terms, however, when running against other candidates the amount of terms they have consecutively served is deducted from the votes cast in their favour. This provides a balance between continuity, equal opportunities and renewal of qualities and competences.
+
+### What about order of preference?
+
+This year the election happens to have 5 seats and 5 candidates. So only confidence needs to be considered.
+
+You may have encountered technical discussions talking about ordering by preference and using this to select the most preferred candidates. That aspect of the voting system is intended to handle a situation where there are _more candidates than seats_. Because we know that is not the case for this election, sorting by preference becomes unnecessary.
+
+[discord-general-wg]: https://discord.com/channels/616186924390023171/631158878108909588
+[statutes-governance]: https://dracc.commonsconservancy.org/0035/#governance "Statutes of Tauri - Governance"


### PR DESCRIPTION
[Rendered](https://github.com/tauri-apps/governance-and-guidance/tree/board-election-2025/board-election-2025)

## TODO:

As per the director running the election, either they will take over this PR or merge and build atop it.