### PR TITLE
Add 2025 vote result

### DIFF
--- a/board-election-2025/README.md
+++ b/board-election-2025/README.md
@@ -9,28 +9,26 @@ We are **inviting Working Group members** to cast their vote on which candidates
 
 ## Election Result
 
-**Pending**
+**All candidates met the threshold and were elected!** 🎉
 
-| Name        |   Elected   | Positive votes | Threshold |
-| ----------- | :---------: | -------------: | --------: |
-| Jacob Bolda | **Pending** |              - |         - |
-| Bill Avery  | **Pending** |              - |         - |
-| Chip Reed   | **Pending** |              - |         - |
-| Fabian-Lars | **Pending** |              - |         - |
+We received **15 votes**. Meaning `>= 8` votes is the confidence threshold.
 
-- _Raw votes: pending_
+| Name        | Elected | Positive votes | Threshold |
+| ----------- | :-----: | -------------: | --------: |
+| Jacob Bolda | **Yes** |             15 |         8 |
+| Chip Reed   | **Yes** |             15 |         8 |
+| Bill Avery  | **Yes** |             14 |         8 |
+| Fabian-Lars | **Yes** |             14 |         8 |
+
+- _Raw votes: [`votes.ndjson`](./votes.ndjson)_
 - _Review: pending_
 
-<!-- TODO: this is all pending vote result.
-
-Taking as reference, currently X people have the Discord `working-group` role.
-A X turnout for the vote based on that number.
+Taking as reference, currently 48 people (and 1 bot) have the Discord `working-group` role.
+A ~31% turnout for the vote based on that number.
 
 The official end of term for the current Directors is _on July 16th_. After this and after making sure they've signed [the Pledge][tcc-plege] the new Directors can take office.
 
 [tcc-plege]: https://dracc.commonsconservancy.org/0016/
-
--->
 
 ## Dates
 

--- a/board-election-2025/votes.ndjson
+++ b/board-election-2025/votes.ndjson
@@ -1,0 +1,15 @@
+{"yes":["jacob-bolda","bill-avery","fabian-lars","chip-reed"],"no":[],"random_id":"ef5bcf90-8bd9-465a-bef6-f4706c8de4ea"}
+{"yes":["jacob-bolda","bill-avery","chip-reed","fabian-lars"],"no":[],"random_id":"a36482db-901c-4744-b477-19148d133a1d"}
+{"yes":["bill-avery","chip-reed","jacob-bolda","fabian-lars"],"no":[],"random_id":"cab64fe2-f2e4-4a70-a979-3307646b6640"}
+{"yes":["chip-reed","jacob-bolda","fabian-lars","bill-avery"],"no":[],"random_id":"029cc38c-a73e-4975-8877-a679de7bd275"}
+{"yes":["fabian-lars","chip-reed","jacob-bolda","bill-avery"],"no":[],"random_id":"e29bba7d-286c-4a2a-9eac-bcdca3573a6b"}
+{"yes":["bill-avery","chip-reed","jacob-bolda","fabian-lars"],"no":[],"random_id":"9402ffd1-502f-4100-889f-6190eb8bcc1c"}
+{"yes":["chip-reed","jacob-bolda"],"no":["fabian-lars","bill-avery"],"random_id":"4e8bf6a8-5169-4f88-9b80-49b137d1bb8b"}
+{"yes":["jacob-bolda","fabian-lars","bill-avery","chip-reed"],"no":[],"random_id":"04fcdcec-dd37-41cc-8135-70895fdd0fbe"}
+{"yes":["chip-reed","bill-avery","jacob-bolda","fabian-lars"],"no":[],"random_id":"c6b80213-15a7-48ec-b535-efbb125087b6"}
+{"yes":["bill-avery","fabian-lars","jacob-bolda","chip-reed"],"no":[],"random_id":"2c4d2d9d-839f-4798-a6a7-6a4ac96224ca"}
+{"yes":["jacob-bolda","bill-avery","chip-reed","fabian-lars"],"no":[],"random_id":"3277e957-9771-45d8-9e95-e69a8717fb8b"}
+{"yes":["jacob-bolda","chip-reed","fabian-lars","bill-avery"],"no":[],"random_id":"f56f32d9-1af3-4da0-b7e3-0c518ba75182"}
+{"yes":["jacob-bolda","fabian-lars","bill-avery","chip-reed"],"no":[],"random_id":"14fd2c14-4e14-4fc2-97df-811906be5779"}
+{"yes":["jacob-bolda","chip-reed","bill-avery","fabian-lars"],"no":[],"random_id":"b33434e7-d40c-4a91-946e-bce977db9e51"}
+{"yes":["jacob-bolda","fabian-lars","chip-reed","bill-avery"],"no":[],"random_id":"40834ca4-f030-4b6b-9aaa-204b4fc5ac98"}


### PR DESCRIPTION
```shell
cd tools
# in bash
cargo run -p count-votes < ../board-election-2025/votes.ndjson
```

```
Summary {
    votes: 15,
    confidence_threshold: 8,
    confidence: {
        "chip-reed",
        "bill-avery",
        "jacob-bolda",
        "fabian-lars",
    },
    yes: {
        "jacob-bolda": 15,
        "chip-reed": 15,
        "bill-avery": 14,
        "fabian-lars": 14,
    },
}
```

## Validation

### By @Beanow 

- [x] All votes were sent by working group members
- [x] All human-readable summaries in the email match the JSON representations
- [x] There are no duplicate `random_id`s
- [x] All votes have an explicit yes/no for all candidates
- [x] My count corroborates the above summary (15 votes, all candidates have confidence)

### By second Director

- [ ] Confirmed the above as well